### PR TITLE
Add GitHub CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: GitHub CI
+
+on:
+  workflow_dispatch:
+  push:
+    paths-ignore:
+      - '.github/*'
+      - '.github/*TEMPLATE/**'
+    branches:
+      - '**'
+  pull_request:
+    paths-ignore:
+      - '*.md'
+      - '.github/*'
+      - '.github/*TEMPLATE/**'
+env:
+  is_pr: ${{ startsWith(github.ref, 'refs/pull/') }}
+  repo_default: 'ergo720/nboxkrnl'
+
+jobs:
+  build:
+    name: ${{ matrix.platform }} (${{ matrix.arch }}, ${{ matrix.configuration }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        cmake-generator:
+          - -A Win32 # Visual Studio (latest IDE)
+        configuration: [Debug, Release]
+        include:
+          - cmake-generator: -A Win32
+            platform: Windows
+            os: windows-latest
+            arch: x86
+            cmake-build-param: -j $env:NUMBER_OF_PROCESSORS
+            folder: win
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Generate CMake Files
+        # NOTES:
+        # -Werror=dev is used to validate CMakeLists.txt for any faults.
+        # TODO: re-add -Werror=dev when submodule is updated to minimal requirement of CMake 3.5
+        run: cmake -B build ${{ matrix.cmake-generator }}
+      - name: Build
+        run: cmake --build build --config ${{ matrix.configuration }} ${{ matrix.cmake-build-param }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.5)
 project(nboxkrnl)
 
 if(NOT DEFINED CMAKE_RUNTIME_OUTPUT_DIRECTORY)


### PR DESCRIPTION
With this pull request, we can verify if the codebase is successfully built on Windows machine. Both linux and macOS machines are not implemented due to requirement using visual studio at this time. **May subject to change in the future.**

> [!NOTE]
> `-Werror=dev` is not included in the CMake's build process due to submodule(s) does not raised minimal CMake requirement per modern CMake does not support below 3.5.