### PR TITLE
Support CMAKE GUI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_CXX_STANDARD 20)
 find_package(Git)
 if(Git_FOUND)
  execute_process(
-  COMMAND git rev-parse HEAD
+  COMMAND git -C ${NBOXKRNL_ROOT_DIR} rev-parse HEAD
   OUTPUT_VARIABLE _NBOXKRNL_VERSION
   OUTPUT_STRIP_TRAILING_WHITESPACE
  )


### PR DESCRIPTION
Not sure this is of any use to you, but doing it this way makes it work with CMake GUI or any other setup where the OS working directory isn't the CMake directory.